### PR TITLE
Copy solr config files

### DIFF
--- a/roles/first_deploy/tasks/main.yml
+++ b/roles/first_deploy/tasks/main.yml
@@ -25,6 +25,14 @@
       repo: https://github.com/curationexperts/{{ project_name }}.git
       dest: /home/{{ ansible_ssh_user }}/{{ project_name }}
 
+- name: copy solr config files
+  become: yes
+  shell: cp /home/{{ ansible_ssh_user }}/{{ project_name }}/solr/config/* /var/solr/data/{{ project_name }}/conf
+
+- name: restart solr
+  become: true
+  service: name=solr state=restarted
+
 - name: install gems (bundle install)
   shell: bundle install
   args:
@@ -51,18 +59,6 @@
 - name: create apache vhosts file
   become: yes
   template: src=apache_vhost.j2 dest=/etc/apache2/sites-enabled/{{ project_name }}.conf owner=root group=root backup=no
-
-- name: symlink schema from code to solr
-  become: yes
-  file: src=/opt/{{ project_name }}/solr/config/schema.xml dest=/var/solr/data/{{ project_name }}/conf/schema.xml state=link force=yes
-
-- name: symlink solrconfig from code to solr
-  become: yes
-  file: src=/opt/{{ project_name }}/solr/config/solrconfig.xml dest=/var/solr/data/{{ project_name }}/conf/solrconfig.xml state=link force=yes
-
-- name: restart solr
-  become: true
-  service: name=solr state=restarted
 
 - name: deploy to production directories with capistrano
   shell: cap localhost deploy


### PR DESCRIPTION
@bess what do you think about this?  There is a complete copy of the repo checked out in the ansible user's home directory with a copy of all of the Solr config files.  We could just copy them from there to the config directory for the Solr collection and then restart Solr before even trying the deploy.  

The down side is that the files wouldn't automatically get updated on future cap deployments.  I'm not sure that Solr really gets updated often enough that this makes a difference.

This might be a good enough first pass that we could refine once we've got MVP of repeatable build.