### PR TITLE
Remove the --bindir="$HOME/bin" flag from ffmpeg config

### DIFF
--- a/roles/ffmpeg/tasks/main.yml
+++ b/roles/ffmpeg/tasks/main.yml
@@ -57,7 +57,6 @@
 - name: configure ffmpeg
   shell: ./configure 
               --extra-libs=-lpthread 
-              --bindir="$HOME/bin" 
               --enable-gpl 
               --enable-libass 
               --enable-libfdk-aac 


### PR DESCRIPTION
AFAICT, this flag causes ffmpeg to install binaries in an
unexpected place. The job says it succeeded, and all supporting
libraries are where they should be, but the actual binaries are
either not being installed at all, or not being installed
where I can find them.

Removing this config option fixes the problem.