### PR TITLE
Adding nailgun roles for alternative way of running FITS

### DIFF
--- a/roles/fits/tasks/main.yml
+++ b/roles/fits/tasks/main.yml
@@ -13,7 +13,7 @@
 - name: setup install directory
   set_fact:
     install_path: /home/{{ ansible_ssh_user }}/install
-    
+
 - name: ensure install directory exists
   file:
     path: '{{ install_path }}'
@@ -42,10 +42,18 @@
 - name: symlink fits alias
   become: yes
   file: src=/usr/local/lib/fits-{{ fits_version }}/fits.sh dest=/usr/local/bin/fits state=link
-  
+
 - name: symlink fits.sh alias
   become: yes
   file: src=/usr/local/lib/fits-{{ fits_version }}/fits.sh dest=/usr/local/bin/fits.sh state=link
+
+- name: make fits-ngserver executable
+  become: yes
+  file: path={{ install_path }}/fits-{{ fits_version }}/fits-ngserver.sh mode=0755
+
+- name: symlink fits-ngserver.sh alias
+  become: yes
+  file: src=/usr/local/lib/fits-{{ fits_version }}/fits-ngserver.sh dest=/usr/local/bin/fits-ngserver.sh state=link
 
 - name: set FITS_HOME in fits-env.sh
   become: yes

--- a/roles/nailgun/tasks/main.yml
+++ b/roles/nailgun/tasks/main.yml
@@ -1,0 +1,55 @@
+# ROLE: nailgun
+# roles/nailgun/tasks/main.yml
+#
+# Installs the nailgun client and server
+# Usage:
+#    - { role: nailgun }
+
+- name: install maven
+  become: yes
+  package: name=maven state=present
+
+- name: setup install directory
+  set_fact:
+    install_path: /home/{{ ansible_ssh_user }}/install
+
+- name: ensure install directory exists
+  file:
+    path: '{{ install_path }}'
+    state: directory
+
+- name: ensure nailgun directory exists
+  file:
+    path: '{{ install_path }}/nailgun'
+    state: directory
+
+- git:
+    repo: 'https://github.com/facebook/nailgun.git'
+    dest: '{{ install_path }}/nailgun'
+
+- name: build ng client
+  command: make
+  args:
+    chdir: '{{ install_path }}/nailgun'
+
+- name: build jars
+  command: mvn install
+  args:
+    chdir: '{{ install_path }}/nailgun'
+
+- name: symlink ng client
+  become: yes
+  file: src='{{ install_path }}/nailgun/ng' dest=/usr/local/bin/ng state=link
+
+- name: install nailgun systemd service
+  template: src=nailgun.j2 dest=/etc/systemd/system/nailgun.service
+
+- name: install fits-ng bash script
+  template: src=fits-ng.j2 dest=/usr/local/bin/fits-ng.sh
+
+- name: make fits-ng executable
+  become: yes
+  file: path=/usr/local/bin/fits-ng.sh mode=0755
+
+- name: start nailgun service
+  systemd: state=started name=nailgun daemon_reload=yes

--- a/roles/nailgun/templates/nailgun.j2
+++ b/roles/nailgun/templates/nailgun.j2
@@ -1,0 +1,8 @@
+[Unit]
+Description=FITS nailgun service
+
+[Service]
+ExecStart=/usr/local/bin/fits-ngserver.sh {{ install_path }}/nailgun/nailgun-server/target/nailgun-server-0.9.2-SNAPSHOT.jar
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This alters the fits role to setup the `fits-nailgun.sh` script 
that is included with fits and adds an additional nailgun role to setup a `systemd` service for
running fits via nailgun.

The template included in the nailgun role allows you to control
the the fits service like this:

`sudo systemctl service nailgun start`
`sudo systemctl service nailgun stop`

The service will be started when the role is run. This allows
you to run fits like this on the server:

`ng edu.harvard.hul.ois.fits.Fits -i somefile.jpg`

To use this in `config/initializers/hyrax/rb`: 

```ruby
  # Path to the file characterization tool
  config.fits_path = "fits-ng.sh /var/repos/nailgun/ng edu.harvard.hul.ois.fits.Fits"
```
  