### PR TITLE
Add a restart role

### DIFF
--- a/roles/restart/tasks/main.yml
+++ b/roles/restart/tasks/main.yml
@@ -1,0 +1,28 @@
+# ROLE: restart
+# roles/restart/tasks/main.yml
+#
+# Restarts essential services
+# Intended to be used after installing packages
+# at the end of the playbook
+# Usage:
+#    - { role: restart }
+
+- name: restart solr
+  become: yes
+  service:
+    name: solr
+    state: restarted
+    
+- name: restart fedora
+  become: yes
+  service:
+    name: tomcat7
+    enabled: yes
+    state: restarted
+
+- name: restart apache
+  become: yes
+  service:
+    name: httpd
+    enabled: yes
+    state: restarted

--- a/roles/restart/tasks/main.yml
+++ b/roles/restart/tasks/main.yml
@@ -23,6 +23,6 @@
 - name: restart apache
   become: yes
   service:
-    name: httpd
+    name: apache2
     enabled: yes
     state: restarted


### PR DESCRIPTION
This commit adds a role that restarts the web server, solr,
and fedora. It's intended to be run at the end of a playbook
to ensure that packages that require apache to be restarted
have it restarted after installation.

Closes #16