### PR TITLE
Add zip to packages list

### DIFF
--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -66,3 +66,4 @@
     - xfsprogs
     - libsqlite3-dev
     - openjdk-8-jdk-headless
+    - zip


### PR DESCRIPTION
This adds zip to the list of packages that are installed
by default. This is needed for geoworks, which is
being implemented at curationexperts/iris.

Closes curationexperts/iris#57