### PR TITLE
Add clamav development libraries.

### DIFF
--- a/roles/clamav/tasks/main.yml
+++ b/roles/clamav/tasks/main.yml
@@ -11,6 +11,7 @@
   become: yes
   with_items:
     - clamav
+    - libclamav-dev
     - clamav-base
     - clamav-daemon
     - clamav-freshclam


### PR DESCRIPTION
Required for compiling virus checking ruby gems.