### PR TITLE
Change branch environment variable to branch_name

### DIFF
--- a/roles/first_deploy/tasks/main.yml
+++ b/roles/first_deploy/tasks/main.yml
@@ -66,7 +66,7 @@
   service: name=apache2 state=restarted
 
 - name: deploy to production directories with capistrano
-  shell: BRANCH={{ branch | default('master') }} cap localhost deploy
+  shell: BRANCH_NAME={{ branch | default('master') }} cap localhost deploy
   args:
     chdir: /home/{{ ansible_ssh_user }}/{{ project_name }}
 


### PR DESCRIPTION
Our Cap deploy scripts are checking for `BRANCH_NAME` and not `BRANCH`. This change
will allow you to specify the branch being deployed in the ansible playbook.