### PR TITLE
Remove solr managed schema

### DIFF
--- a/roles/solr/tasks/main.yml
+++ b/roles/solr/tasks/main.yml
@@ -40,6 +40,12 @@
   shell: bash {{ install_path }}/solr-{{ solr_version }}/bin/install_solr_service.sh {{ install_path }}/solr-{{ solr_version }}.tgz -p {{ solr_port }}
   when: solr_init_script.stat.exists == False
 
+- name: remove managed schema
+  become: yes
+  file:
+    path: /var/solr/data/{{ project_name }}/conf/managed_schema
+    state: absent
+
 - name: create default collection
   become: yes
   become_user: solr


### PR DESCRIPTION
The first_deploy task should make sure that the managed_schema file that comes with solr is deleted. 

If it isn't deleted the core that is created is based on `managed_schema` not `schema.xml`. 

DCE projects do not use `managed_schema` and our solr config files specify 
the classic way of defining the schema: 

https://github.com/curationexperts/laevigata/blob/master/solr/config/solrconfig.xml#L44
https://github.com/curationexperts/mahonia/blob/master/solr/config/solrconfig.xml#L44
https://github.com/curationexperts/epigaea/blob/master/solr/config/solrconfig.xml#L44

See also: https://stackoverflow.com/questions/30673095/using-schema-xml-instead-of-managed-schema-with-solr-5-1-x