### PR TITLE
Change installed to present in packages role

### DIFF
--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -32,7 +32,7 @@
 
 - name: install dev tools and libraries
   become: yes
-  package: name={{ item }} state=installed
+  package: name={{ item }} state=present
   with_items:
     - build-essential
     - git


### PR DESCRIPTION
This needs to be changes to get rid of the deprecation warning:
```
[DEPRECATION WARNING]: State 'installed' is deprecated. Using state 'present' instead.. This feature will be removed in version 2.9. Deprecation warnings can be 
disabled by setting deprecation_warnings=False in ansible.cfg.
```