### PR TITLE
Fedora with postgres

### DIFF
--- a/roles/fedora/defaults/main.yml
+++ b/roles/fedora/defaults/main.yml
@@ -10,12 +10,10 @@ tomcat_max_memory: 4096m
 
 fedora_config_file: /etc/default/tomcat7
 
-fedora_version: 4.7.1
-#fedora_database only used in Fedora versions >= 4.6.0
-fedora_database: file-simple
-# for fcrepo 4.6.x, use minimal-default
-fcdb_user: admin
-fcdb_pass: admin123
+fedora_version: 4.7.5
+fedora_database: jdbc-postgresql
+# fcdb_user: admin
+# fcdb_pass: admin123
 fcdb_port: 5432
 
 tomcat_port: 8080

--- a/roles/fedora/tasks/main.yml
+++ b/roles/fedora/tasks/main.yml
@@ -2,11 +2,25 @@
 # ROLE: fedora
 # roles/fedora/tasks/main.yml
 #
+# To back fedora with postgres, set these variables:
+# fedora_database: jdbc-postgresql
+# fcdb_user: fcdb_user
+# fcdb_pass: whatever
+# You must also create a postgres database called `fcrepo` and give the fcdb_user
+# rights on it
+# Note that backing fedora with PostGres is our default and is ALWAYS how we want
+# to run things in production.
+
+- name: create fcrepo database
+  postgresql_db: name=fcrepo state=present login_user=postgres login_password={{ postgres_pass }}
+
+- name: add samvera user
+  postgresql_user: db=fcrepo name={{ fcdb_user }} password={{ fcdb_pass }} priv=ALL state=present login_user=postgres login_password={{ postgres_pass }}
 
 - name: setup install directory
   set_fact:
     install_path: /home/{{ ansible_ssh_user }}/install
-    
+
 - name: ensure install directory exists
   file:
     path: '{{ install_path }}'
@@ -32,7 +46,7 @@
   command: cp {{ install_path }}/fcrepo-webapp-{{ fedora_version }}.war /var/lib/tomcat7/webapps/fedora.war
   when: fedora_war.stat.exists == False
 
-- name: create tomcat config and java options for Fedora 4.6+
+- name: create tomcat config and java options
   become: yes
   template:
     src: tomcat7.j2
@@ -40,8 +54,6 @@
     owner: tomcat7
     group: tomcat7
     backup: yes
-  when:
-    - fedora_version | match("^4\.[6-9]\.[0-9]")
 
 - name: set port for tomcat
   become: yes

--- a/roles/fedora/templates/tomcat7.j2
+++ b/roles/fedora/templates/tomcat7.j2
@@ -5,4 +5,20 @@
 # TOMCAT_GROUP=tomcat
 TOMCAT7_USER=tomcat7
 TOMCAT7_GROUP=tomcat7
-JAVA_OPTS="-Dfcrepo.home=/opt/fedora-data -Dfcrepo.modeshape.configuration=classpath:/config/{{ fedora_database }}/repository.json -Djava.awt.headless=true -XX:+UseG1GC -XX:+UseCompressedOops -XX:-UseLargePagesIndividualAllocation -XX:MaxPermSize={{ tomcat_permgen_memory }} -Xms{{ tomcat_min_memory }} -Xmx{{ tomcat_max_memory }} -Djava.util.logging.config.file=/etc/tomcat7/logging.properties -server"
+# JAVA_OPTS="-Dfcrepo.home=/opt/fedora-data -Dfcrepo.modeshape.configuration=classpath:/config/{{ fedora_database }}/repository.json -Djava.awt.headless=true -XX:+UseG1GC -XX:+UseCompressedOops -XX:-UseLargePagesIndividualAllocation -XX:MaxPermSize={{ tomcat_permgen_memory }} -Xms{{ tomcat_min_memory }} -Xmx{{ tomcat_max_memory }} -Djava.util.logging.config.file=/etc/tomcat7/logging.properties -server"
+
+JAVA_OPTS="${JAVA_OPTS} -Dfcrepo.home=/opt/fedora-data"
+JAVA_OPTS="${JAVA_OPTS} -Dfcrepo.modeshape.configuration=classpath:/config/jdbc-postgresql/repository.json"
+JAVA_OPTS="${JAVA_OPTS} -Dfcrepo.postgresql.username={{ fcdb_user }}"
+JAVA_OPTS="${JAVA_OPTS} -Dfcrepo.postgresql.password={{ fcdb_pass }}"
+JAVA_OPTS="${JAVA_OPTS} -Dfcrepo.postgresql.host=localhost"
+JAVA_OPTS="${JAVA_OPTS} -Dfcrepo.postgresql.port=5432"
+JAVA_OPTS="${JAVA_OPTS} -Djava.awt.headless=true"
+JAVA_OPTS="${JAVA_OPTS} -XX:+UseG1GC"
+JAVA_OPTS="${JAVA_OPTS} -XX:+UseCompressedOops"
+JAVA_OPTS="${JAVA_OPTS} -XX:-UseLargePagesIndividualAllocation"
+JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize={{ tomcat_permgen_memory }}"
+JAVA_OPTS="${JAVA_OPTS} -Xms{{ tomcat_min_memory }}"
+JAVA_OPTS="${JAVA_OPTS} -Xmx{{ tomcat_max_memory }}"
+JAVA_OPTS="${JAVA_OPTS} -Djava.util.logging.config.file=/etc/tomcat7/logging.properties"
+JAVA_OPTS="${JAVA_OPTS} -server"

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -57,13 +57,6 @@
 - name: create samvera database
   postgresql_db: name={{ project_name }} state=present login_user=postgres login_password={{ postgres_pass }}
 
-- name: create samvera database
-  postgresql_db: name=fcrepo state=present login_user=postgres login_password={{ postgres_pass }}
-  tags: temptag
-
 - name: add samvera user
   postgresql_user: db={{ project_name }} name={{ db_user }} password={{ db_pass }} priv=ALL state=present login_user=postgres login_password={{ postgres_pass }}
 
-- name: add fcrepo user
-  postgresql_user: db=fcrepo name={{ fcdb_user }} password={{ fcdb_pass }} priv=ALL state=present login_user=postgres login_password={{ postgres_pass }}
-  tags: temptag

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -59,3 +59,7 @@
 
 - name: add samvera user
   postgresql_user: db={{ project_name }} name={{ db_user }} password={{ db_pass }} priv=ALL state=present login_user=postgres login_password={{ postgres_pass }}
+
+- name: add fcrepo user
+  postgresql_user: db=fcrepo name={{ fcdb_user }} password={{ fcdb_pass }} priv=ALL state=present login_user=postgres login_password={{ postgres_pass }}
+  tags: temptag

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -57,6 +57,10 @@
 - name: create samvera database
   postgresql_db: name={{ project_name }} state=present login_user=postgres login_password={{ postgres_pass }}
 
+- name: create samvera database
+  postgresql_db: name=fcrepo state=present login_user=postgres login_password={{ postgres_pass }}
+  tags: temptag
+
 - name: add samvera user
   postgresql_user: db={{ project_name }} name={{ db_user }} password={{ db_pass }} priv=ALL state=present login_user=postgres login_password={{ postgres_pass }}
 

--- a/roles/postgres/templates/pg_backups.j2
+++ b/roles/postgres/templates/pg_backups.j2
@@ -1,8 +1,16 @@
 #!/bin/bash
-export PGPASSWORD="{{ db_pass | default('my_db_password') }}"
+export PGPASSWORD="{{ db_pass }}"
 # removes 2-day-old backup
 rm /opt/pg_backups/samvera_day_old.bak
 # renames latest backup to day-old
 mv /opt/pg_backups/samvera.bak /opt/pg_backups/samvera_day_old.bak
 # does fresh backup of samvera database
-pg_dump -U {{ db_user | default('my_db_user') }} {{ db | default('samvera') }} > /opt/pg_backups/samvera.bak
+pg_dump -U {{ db_user }} {{ project_name }} > /opt/pg_backups/samvera.bak
+
+export PGPASSWORD="{{ postgres_pass }}"
+# removes 2-day-old backup
+rm /opt/pg_backups/fcrepo_day_old.bak
+# renames latest backup to day-old
+mv /opt/pg_backups/fcrepo.bak /opt/pg_backups/fcrepo_day_old.bak
+# does fresh backup of samvera database
+pg_dump -U {{ fcdb_user }} fcrepo > /opt/pg_backups/fcrepo.bak


### PR DESCRIPTION
Back fedora with postgres
* Make backing fedora with postgres the default
* Re-structure the fedora tomcat config file to make it easier to read
* Remove the creation of the fedora database from the postgres role
and have it in the fedora role instead
* Update postgres backup scripts to include fedora database

Connected to https://github.com/curationexperts/laevigata/issues/1063