### PR TITLE
Add meta file for use from Galaxy

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,15 @@
+---
+galaxy_info:
+  author: Data Curation Experts
+  description: Samvera Ansible Roles
+  license: AFL v2.0
+  min_ansible_version: 1.8
+  platforms:
+  - name: Ubuntu
+    versions:
+    - all
+  categories:
+  - system
+  - web
+dependencies: []
+allow_duplicates: yes


### PR DESCRIPTION
These roles can be pulled from their GitHub repository at the point of build using Ansible Galaxy if the project has a meta file.