### PR TITLE
Add gis_sources var syntax

### DIFF
--- a/roles/simple-tiles/tasks/main.yml
+++ b/roles/simple-tiles/tasks/main.yml
@@ -34,7 +34,7 @@
 - name: unzip simple-tiles source
   shell: tar zxvf v{{ simple_tiles_ver }}.tar.gz creates=simple-tiles-{{ simple_tiles_ver }} warn=no
   args:
-    chdir: gis_sources
+    chdir: "{{ gis_sources  }}"
 
 - name: configure simple-tiles
   shell: ./configure


### PR DESCRIPTION
I'm not 100% on this one because I haven't been able to get this role to run yet (because libpoppler is compiled with libtiff5 on my version of Ubuntu and this role seems to want libtiff4), but shouldn't the gis_sources be wrapped indicating it's a variable. Not an ansible expert so it may be it doesn't need to be, but suggesting it anyway for consistency of form if that's true.