### PR TITLE
Use 'become' instead of 'sudo' on yarn task

### DIFF
--- a/roles/yarn/tasks/main.yml
+++ b/roles/yarn/tasks/main.yml
@@ -1,5 +1,6 @@
 - name: get the gpg keys for yarn
-  shell: curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+  become: true
+  shell: curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 
 - name: add yarn repos to apt
   become: true


### PR DESCRIPTION
Makes it able to run under Packer and should work with standalone Ansible just fine too.