### PR TITLE
Create symlink for solr logs in /var/log

### DIFF
--- a/roles/solr/tasks/main.yml
+++ b/roles/solr/tasks/main.yml
@@ -64,3 +64,11 @@
   systemd:
     name: solr
     state: restarted
+
+- name: symlink solr logs to /var/log
+  become: yes
+  file:
+    src: "/var/solr/logs"
+    dest: "/var/log/solr"
+    state: link
+


### PR DESCRIPTION
It's nice to have a symlink here since /var/log is where people often look for logs.