### PR TITLE
Add .pgpass for system user [fixes #62]

### DIFF
--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -5,3 +5,5 @@
 postgres_pass: postgres
 db_user: my__db_user
 db_pass: my_db_pass
+system_user: ubuntu
+system_password: my_ubuntu_pass

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -50,6 +50,10 @@
     regexp: '^local\s+all\s+all'
     line: 'local	all		all						md5'
 
+- name: create .pgpass for the system user to save them from typing passwords
+  become: yes
+  template: src=pgpass.j2 dest="/home/{{ system_user }}/.pgpass" owner="{{ system_user }}" group="{{ system_user }}" mode=0600
+
 - name: restart postgres server
   become: yes
   service: name=postgresql enabled=yes state=restarted

--- a/roles/postgres/templates/pgpass.j2
+++ b/roles/postgres/templates/pgpass.j2
@@ -1,0 +1,1 @@
+localhost:*:*:{{ system_user }}:{{ system_password }}


### PR DESCRIPTION
A possible implementation for issue #62. Adds a .pgpass file so the person logged into the machine doesn't have to type psql passwords.