### PR TITLE
Rotate rails logs

### DIFF
--- a/roles/setup_logrotation/templates/logrotate-sys.j2
+++ b/roles/setup_logrotation/templates/logrotate-sys.j2
@@ -11,14 +11,15 @@
         endscript
 }
 
-/opt/{{ project_name }}/log/production.log
+/opt/{{ project_name }}/shared/log/*.log
 {
-        copytruncate
-        daily
-        rotate 30
-        compress
-        missingok
-        create 0644 deploy deploy
+  daily
+  missingok
+  rotate 7
+  compress
+  delaycompress
+  notifempty
+  copytruncate
 }
 
 /var/log/mail.info


### PR DESCRIPTION
Rails log rotation was broken because it was pointing
at the wrong directory (it was missing the "shared"
directory, which is part of the capistrano deploy pattern)
Also updated: Rotate all rails logs, not only production.log