### PR TITLE
Make ansible-samvera work for spotlight

### DIFF
--- a/roles/first_deploy/tasks/main.yml
+++ b/roles/first_deploy/tasks/main.yml
@@ -75,15 +75,9 @@
   become: yes
   service: name=apache2 state=restarted
 
-- name: remove managed schema
-  become: yes
-  file:
-    path: /var/solr/data/{{ project_name }}/conf/managed_schema
-    state: absent
-
 - name: temporary symlink schema from git checkout to solr
   become: yes
-  file: src=/home/{{ ansible_ssh_user }}/{{ project_name }}/solr/config/schema.xml dest=/var/solr/data/{{ project_name }}/conf/schema.xml state=link force=yes
+  file: src=/home/{{ ansible_ssh_user }}/{{ project_name }}/solr/config/schema.xml dest=/var/solr/data/{{ project_name }}/conf/managed-schema state=link force=yes
 
 - name: temporary symlink solrconfig from git checkout to solr
   become: yes
@@ -98,13 +92,13 @@
   args:
     chdir: /home/{{ ansible_ssh_user }}/{{ project_name }}
 
-- name: symlink schema from code to solr
-  become: yes
-  file: src=/opt/{{ project_name }}/current/solr/config/schema.xml dest=/var/solr/data/{{ project_name }}/conf/schema.xml state=link force=yes
-
 - name: symlink solrconfig from code to solr
   become: yes
   file: src=/opt/{{ project_name }}/current/solr/config/solrconfig.xml dest=/var/solr/data/{{ project_name }}/conf/solrconfig.xml state=link force=yes
+
+- name: symlink schema from code to solr
+  become: yes
+  file: src=/opt/{{ project_name }}/current/solr/config/schema.xml dest=/var/solr/data/{{ project_name }}/conf/managed-schema state=link force=yes
 
 - name: restart solr
   become: true
@@ -113,10 +107,3 @@
 - name: restart apache to load newly configured passenger application
   become: yes
   service: name=apache2 state=restarted
-
-- name: ensure default admin set with rake
-  become: yes
-  become_user: deploy
-  shell: RAILS_ENV=production bundle exec rake hyrax:default_admin_set:create
-  args:
-    chdir: /opt/{{ project_name }}/current

--- a/roles/hyrax_rake_tasks/tasks/main.yml
+++ b/roles/hyrax_rake_tasks/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+# ROLE: hyrax_rake_tasks
+# roles/hyrax_rake_tasks/tasks/main.yml
+#
+# When hyrax is first installed, there are a few rake tasks that must be run.
+# Usage:
+#    - { role: hyrax_rake_tasks, project_name: *required*, branch: <optional> }
+#
+
+- name: ensure default admin set with rake
+  become: yes
+  become_user: deploy
+  shell: RAILS_ENV=production bundle exec rake hyrax:default_admin_set:create
+  args:
+    chdir: /opt/{{ project_name }}/current
+
+- name: ensure default collection types
+  become: yes
+  become_user: deploy
+  shell: RAILS_ENV=production bundle exec rake hyrax:default_collection_types:create
+  args:
+    chdir: /opt/{{ project_name }}/current

--- a/roles/restart_apache/tasks/main.yml
+++ b/roles/restart_apache/tasks/main.yml
@@ -1,0 +1,15 @@
+# ROLE: restart apache
+# roles/restart_apache/tasks/main.yml
+#
+# Restarts essential services
+# Intended to be used after installing packages
+# at the end of the playbook
+# Usage:
+#    - { role: restart_apache }
+
+- name: restart apache
+  become: yes
+  service:
+    name: apache2
+    enabled: yes
+    state: restarted

--- a/roles/restart_solr/tasks/main.yml
+++ b/roles/restart_solr/tasks/main.yml
@@ -1,0 +1,14 @@
+# ROLE: restart solr
+# roles/restart_solr/tasks/main.yml
+#
+# Restarts essential services
+# Intended to be used after installing packages
+# at the end of the playbook
+# Usage:
+#    - { role: restart_solr }
+
+- name: restart solr
+  become: yes
+  service:
+    name: solr
+    state: restarted


### PR DESCRIPTION
Break hyrax specific tasks out of first-deploy.
Enable restarting solr and apache separately, so
those tasks can be used on a system that doesn't
have fedora installed.