### PR TITLE
Sym link both schema.xml and managed-schema

### DIFF
--- a/roles/first_deploy/tasks/main.yml
+++ b/roles/first_deploy/tasks/main.yml
@@ -75,9 +75,13 @@
   become: yes
   service: name=apache2 state=restarted
 
-- name: temporary symlink schema from git checkout to solr
+- name: temporary symlink schema from git checkout to solr - managed-schema
   become: yes
   file: src=/home/{{ ansible_ssh_user }}/{{ project_name }}/solr/config/schema.xml dest=/var/solr/data/{{ project_name }}/conf/managed-schema state=link force=yes
+
+- name: temporary symlink schema from git checkout to solr - schema.xml
+  become: yes
+  file: src=/home/{{ ansible_ssh_user }}/{{ project_name }}/solr/config/schema.xml dest=/var/solr/data/{{ project_name }}/conf/schema.xml state=link force=yes
 
 - name: temporary symlink solrconfig from git checkout to solr
   become: yes
@@ -96,9 +100,13 @@
   become: yes
   file: src=/opt/{{ project_name }}/current/solr/config/solrconfig.xml dest=/var/solr/data/{{ project_name }}/conf/solrconfig.xml state=link force=yes
 
-- name: symlink schema from code to solr
+- name: symlink schema from code to solr - managed-schema
   become: yes
   file: src=/opt/{{ project_name }}/current/solr/config/schema.xml dest=/var/solr/data/{{ project_name }}/conf/managed-schema state=link force=yes
+
+- name: symlink schema from git checkout to solr - schema.xml
+  become: yes
+  file: src=/home/{{ ansible_ssh_user }}/{{ project_name }}/solr/config/schema.xml dest=/var/solr/data/{{ project_name }}/conf/schema.xml state=link force=yes
 
 - name: restart solr
   become: true


### PR DESCRIPTION
Some versions of solr seem to expect schema.xml, and
some seem to want managed-schema. It doesn't seem
to hurt anything to have sym links to both.