### PR TITLE
Add fits-servlet to fits role

### DIFF
--- a/roles/fits/defaults/main.yml
+++ b/roles/fits/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+# roles/fits/defaults/main.yml
+
+tomcat_port: 8080
+fits_servlet_checksum: D9EC15B1329ED653AFCF0D81D824FDB200EC1B3D378E6C4D2FE3B0B6C30EF1AE

--- a/roles/fits/tasks/main.yml
+++ b/roles/fits/tasks/main.yml
@@ -10,6 +10,11 @@
     fits_version: '1.4.0'
   when: fits_version is not defined
 
+- name: ensure fits_servlet_version is set
+  set_fact:
+    fits_servlet_version: '1.2.0'
+  when: fits_servlet_version is not defined
+
 - name: setup install directory
   set_fact:
     install_path: /home/{{ ansible_ssh_user }}/install
@@ -28,13 +33,18 @@
   become: yes
   package: name=unzip state=present
 
+- name: ensure fits installation directory exists
+  file:
+    path: '{{ install_path }}/fits-{{ fits_version}}'
+    state: directory
+
 - name: download fits zip version {{ fits_version }}
   become: yes
   get_url: url=https://github.com/harvard-lts/fits/releases/download/{{ fits_version }}/fits-{{ fits_version }}.zip owner={{ ansible_ssh_user }} dest={{ install_path }}/fits-{{ fits_version }}.zip
 
 - name: unpack fits
   become: yes
-  unarchive: src={{ install_path }}/fits-{{ fits_version }}.zip dest={{ install_path }}/fits-{{ fits_version }} creates={{ install_path }}/fits-{{ fits_version }}/fits.sh copy=no
+  unarchive: src={{ install_path }}/fits-{{ fits_version }}.zip dest={{ install_path }}/fits-{{ fits_version}} creates={{ install_path }}/fits-{{ fits_version }}/fits.sh copy=no
 
 - name: make fits executable
   become: yes
@@ -55,9 +65,55 @@
 - name: set FITS_HOME in fits-env.sh
   become: yes
   lineinfile: dest=/usr/local/lib/fits-{{ fits_version }}/fits-env.sh regexp=^FITS_HOME line=FITS_HOME="/usr/local/lib/fits-{{ fits_version }}" state=present
-  when: fits_version | match("^0\.([8-9]|10)\.[0-9]|1\.[0-9]\.[0-9]")
+  when: fits_version is match("^0\.([8-9]|10)\.[0-9]|1\.[0-9]\.[0-9]")
 
 - name: symlink fits-env.sh alias
   become: yes
   file: src=/usr/local/lib/fits-{{ fits_version }}/fits-env.sh dest=/usr/local/bin/fits-env.sh state=link
-  when: fits_version | match("^0\.([8-9]|10)\.[0-9]|1\.[0-9]\.[0-9]")
+  when: fits_version is match("^0\.([8-9]|10)\.[0-9]|1\.[0-9]\.[0-9]")
+
+- name: install servlet container package
+  become: yes
+  package: name=tomcat7 state=present
+
+- name: download fits servlet version {{ fits_servlet_version }}
+  become: yes
+  get_url:
+    url: 'https://projects.iq.harvard.edu/files/fits/files/fits-{{ fits_servlet_version }}.war'
+    owner: tomcat7
+    group: tomcat7
+    dest: '{{ install_path }}/fits-{{ fits_servlet_version }}.war'
+    checksum: 'sha256:{{ fits_servlet_checksum }}'
+    force: yes
+
+- name: copy over fits.war
+  become: yes
+  command: cp {{ install_path }}/fits-{{ fits_servlet_version }}.war /var/lib/tomcat7/webapps/fits-{{ fits_servlet_version }}.war
+
+- name: copy catalina properties
+  become: yes
+  template:
+    src: catalina.properties.j2
+    dest: /etc/tomcat7/catalina.properties
+    owner: tomcat7
+    group: tomcat7
+    backup: yes
+
+- name: set port for tomcat
+  become: yes
+  replace:
+    dest: /etc/tomcat7/server.xml
+    regexp: "8080"
+    replace: "{{ tomcat_port }}"
+
+- name: add log rotation for catalina.out (tomcat/fedora logs)
+  become: yes
+  template: src=logrotate-tomcat dest=/etc/logrotate.d/tomcat7 backup=yes
+
+- name: restart servlet
+  become: yes
+  service: name=tomcat7 enabled=yes state=restarted
+
+- name: check that fits-servlet is up
+  uri:
+    url: 'http://localhost:{{tomcat_port}}/fits-{{ fits_servlet_version}}/'

--- a/roles/fits/templates/catalina.properties.j2
+++ b/roles/fits/templates/catalina.properties.j2
@@ -1,0 +1,201 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+fits.home=/usr/local/lib/fits-{{ fits_version }}
+
+#
+# List of comma-separated packages that start with or equal this string
+# will cause a security exception to be thrown when
+# passed to checkPackageAccess unless the
+# corresponding RuntimePermission ("accessClassInPackage."+package) has
+# been granted.
+package.access=sun.,org.apache.catalina.,org.apache.coyote.,org.apache.jasper.,\
+org.apache.naming.resources.,org.apache.tomcat.
+#
+# List of comma-separated packages that start with or equal this string
+# will cause a security exception to be thrown when
+# passed to checkPackageDefinition unless the
+# corresponding RuntimePermission ("defineClassInPackage."+package) has
+# been granted.
+#
+# by default, no packages are restricted for definition, and none of
+# the class loaders supplied with the JDK call checkPackageDefinition.
+#
+package.definition=sun.,java.,org.apache.catalina.,org.apache.coyote.,\
+org.apache.jasper.,org.apache.naming.,org.apache.tomcat.
+
+#
+#
+# List of comma-separated paths defining the contents of the "common"
+# classloader. Prefixes should be used to define what is the repository type.
+# Path may be relative to the CATALINA_HOME or CATALINA_BASE path or absolute.
+# If left as blank,the JVM system loader will be used as Catalina's "common"
+# loader.
+# Examples:
+#     "foo": Add this folder as a class repository
+#     "foo/*.jar": Add all the JARs of the specified folder as class
+#                  repositories
+#     "foo/bar.jar": Add bar.jar as a class repository
+common.loader=${catalina.base}/lib,${catalina.base}/lib/*.jar,${catalina.home}/lib,${catalina.home}/lib/*.jar
+
+#
+# List of comma-separated paths defining the contents of the "server"
+# classloader. Prefixes should be used to define what is the repository type.
+# Path may be relative to the CATALINA_HOME or CATALINA_BASE path or absolute.
+# If left as blank, the "common" loader will be used as Catalina's "server"
+# loader.
+# Examples:
+#     "foo": Add this folder as a class repository
+#     "foo/*.jar": Add all the JARs of the specified folder as class
+#                  repositories
+#     "foo/bar.jar": Add bar.jar as a class repository
+server.loader=
+
+#
+# List of comma-separated paths defining the contents of the "shared"
+# classloader. Prefixes should be used to define what is the repository type.
+# Path may be relative to the CATALINA_BASE path or absolute. If left as blank,
+# the "common" loader will be used as Catalina's "shared" loader.
+# Examples:
+#     "foo": Add this folder as a class repository
+#     "foo/*.jar": Add all the JARs of the specified folder as class
+#                  repositories
+#     "foo/bar.jar": Add bar.jar as a class repository
+# Please note that for single jars, e.g. bar.jar, you need the URL form
+# starting with file:.
+shared.loader=${fits.home}/lib/*.jar
+
+# List of JAR files that should not be scanned using the JarScanner
+# functionality. This is typically used to scan JARs for configuration
+# information. JARs that do not contain such information may be excluded from
+# the scan to speed up the scanning process. This is the default list. JARs on
+# this list are excluded from all scans. Scan specific lists (to exclude JARs
+# from individual scans) follow this. The list must be a comma separated list of
+# JAR file names.
+# The JARs listed below include:
+# - Tomcat Bootstrap JARs
+# - Tomcat API JARs
+# - Catalina JARs
+# - Jasper JARs
+# - Tomcat JARs
+# - Common non-Tomcat JARs
+# - Test JARs (JUnit, Cobertura and dependencies)
+tomcat.util.scan.DefaultJarScanner.jarsToSkip=\
+annotations-api.jar,\
+ant-junit*.jar,\
+ant-launcher.jar,\
+ant.jar,\
+asm-*.jar,\
+aspectj*.jar,\
+bootstrap.jar,\
+catalina-ant.jar,\
+catalina-ha.jar,\
+catalina-jmx-remote.jar,\
+catalina-tribes.jar,\
+catalina-ws.jar,\
+catalina.jar,\
+cobertura-*.jar,\
+commons-beanutils*.jar,\
+commons-codec*.jar,\
+commons-collections*.jar,\
+commons-daemon.jar,\
+commons-dbcp*.jar,\
+commons-digester*.jar,\
+commons-fileupload*.jar,\
+commons-httpclient*.jar,\
+commons-io*.jar,\
+commons-lang*.jar,\
+commons-logging*.jar,\
+commons-math*.jar,\
+commons-pool*.jar,\
+dom4j-*.jar,\
+ecj-*.jar,\
+el-api.jar,\
+geronimo-spec-jaxrpc*.jar,\
+h2*.jar,\
+hamcrest-*.jar,\
+hibernate*.jar,\
+httpclient*.jar,\
+icu4j-*.jar,\
+jasper-el.jar,\
+jasper.jar,\
+jaxb-*.jar,\
+jaxen-*.jar,\
+jdom-*.jar,\
+jetty-*.jar,\
+jmx-tools.jar,\
+jmx.jar,\
+jsp-api.jar,\
+jstl.jar,\
+jta*.jar,\
+junit-*.jar,\
+junit.jar,\
+log4j-1*.jar,\
+log4j*.jar,\
+mail*.jar,\
+org.hamcrest.*.jar,\
+oraclepki.jar,\
+oro-*.jar,\
+servlet-api-*.jar,\
+servlet-api.jar,\
+slf4j*.jar,\
+taglibs-standard-spec-*.jar,\
+tagsoup-*.jar,\
+tomcat-api.jar,\
+tomcat-coyote.jar,\
+tomcat-dbcp.jar,\
+tomcat-i18n-en.jar,\
+tomcat-i18n-es.jar,\
+tomcat-i18n-fr.jar,\
+tomcat-i18n-ja.jar,\
+tomcat-i18n-ru.jar,\
+tomcat-jdbc.jar,\
+tomcat-jni.jar,\
+tomcat-juli-adapters.jar,\
+tomcat-juli.jar,\
+tomcat-spdy.jar,\
+tomcat-util.jar,\
+tools.jar,\
+websocket-api.jar,\
+wsdl4j*.jar,\
+xercesImpl.jar,\
+xml-apis.jar,\
+xmlParserAPIs-*.jar,\
+xmlParserAPIs.jar,\
+xom-*.jar
+
+# Additional JARs (over and above the default JARs listed above) to skip when
+# scanning for Servlet 3.0 pluggability features. These features include web
+# fragments, annotations, SCIs and classes that match @HandlesTypes. The list
+# must be a comma separated list of JAR file names.
+org.apache.catalina.startup.ContextConfig.jarsToSkip=
+
+# Additional JARs (over and above the default JARs listed above) to skip when
+# scanning for TLDs. The list must be a comma separated list of JAR file names.
+org.apache.catalina.startup.TldConfig.jarsToSkip=tomcat7-websocket.jar
+
+#
+# String cache configuration.
+tomcat.util.buf.StringCache.byte.enabled=true
+#tomcat.util.buf.StringCache.char.enabled=true
+#tomcat.util.buf.StringCache.trainThreshold=500000
+#tomcat.util.buf.StringCache.cacheSize=5000
+
+# This system property is deprecated. Use the relaxedPathChars relaxedQueryChars
+# attributes of the Connector instead. These attributes permit a wider range of
+# characters to be configured as valid.
+# Allow for changes to HTTP request validation
+# WARNING: Using this option may expose the server to CVE-2016-6816
+#tomcat.util.http.parser.HttpParser.requestTargetAllow=|

--- a/roles/fits/templates/logrotate-tomcat
+++ b/roles/fits/templates/logrotate-tomcat
@@ -1,0 +1,8 @@
+/var/log/tomcat7/catalina.out {
+  copytruncate
+  weekly
+  rotate 52
+  compress
+  missingok
+  create 640 tomcat7 adm
+}


### PR DESCRIPTION
This adds changes to the fits role so that the
`fits-servlet` application is also installed. This involves
setting up Tomcat to run the war.

The role downloads the war and sets up tomcat
so that it will be run. The last task in the role
checks to see if it is running.

This role can be ran without running the fedora role
which also installs tomcat, or it can be run alongside
that fedora role.