### PR TITLE
Do not set group for downloaded

### DIFF
--- a/roles/fedora/tasks/main.yml
+++ b/roles/fedora/tasks/main.yml
@@ -31,7 +31,7 @@
   package: name=tomcat7 state=present
 
 - name: download fedora
-  get_url: url=http://repo1.maven.org/maven2/org/fcrepo/fcrepo-webapp/{{ fedora_version }}/fcrepo-webapp-{{ fedora_version }}.war owner={{ ansible_ssh_user }} group={{ ansible_ssh_user }} dest={{ install_path }}/fcrepo-webapp-{{ fedora_version }}.war timeout=100
+  get_url: url=http://repo1.maven.org/maven2/org/fcrepo/fcrepo-webapp/{{ fedora_version }}/fcrepo-webapp-{{ fedora_version }}.war owner={{ ansible_ssh_user }} dest={{ install_path }}/fcrepo-webapp-{{ fedora_version }}.war timeout=100
 
 - name: make fedora data dir
   file: owner=tomcat7 group=tomcat7 state=directory path=/opt/fedora-data

--- a/roles/fits/tasks/main.yml
+++ b/roles/fits/tasks/main.yml
@@ -30,7 +30,7 @@
 
 - name: download fits zip version {{ fits_version }}
   become: yes
-  get_url: url=https://github.com/harvard-lts/fits/releases/download/{{ fits_version }}/fits-{{ fits_version }}.zip owner={{ ansible_ssh_user }} group={{ ansible_ssh_user }} dest={{ install_path }}/fits-{{ fits_version }}.zip
+  get_url: url=https://github.com/harvard-lts/fits/releases/download/{{ fits_version }}/fits-{{ fits_version }}.zip owner={{ ansible_ssh_user }} dest={{ install_path }}/fits-{{ fits_version }}.zip
 
 - name: unpack fits
   become: yes


### PR DESCRIPTION
This changes the roles that download fedora
and fits so that they do not set a group
for the files. This is so you can use
user-based sudo.