### PR TITLE
Remove ImageMagick group from downloads

### DIFF
--- a/roles/imagemagick/tasks/im_libraries.yml
+++ b/roles/imagemagick/tasks/im_libraries.yml
@@ -11,7 +11,7 @@
 
 - name: create IM sources dir
   become: yes
-  file: owner={{ ansible_ssh_user }} group={{ ansible_ssh_user }} state=directory path=imagemagick_sources
+  file: owner={{ ansible_ssh_user }} state=directory path=imagemagick_sources
 
 - name: IM add ldconfig for /usr/local/lib
   become: yes

--- a/roles/simple-tiles/tasks/main.yml
+++ b/roles/simple-tiles/tasks/main.yml
@@ -9,12 +9,12 @@
 
 - name: create gis sources dir
   become: yes
-  file: owner={{ ansible_ssh_user }} group={{ ansible_ssh_user }} state=directory path=/home/{{ ansible_ssh_user }}/gis_sources
+  file: owner={{ ansible_ssh_user }} state=directory path=/home/{{ ansible_ssh_user }}/gis_sources
 
 - name: set gis sources dir
   set_fact:
     gis_sources: /home/{{ ansible_ssh_user }}/gis_sources
-    
+
 # - name: Install GDAL and required packages
 - name: Install geo_works required packages
   become: yes


### PR DESCRIPTION
This removes the group permission change for
downloads related to ImageMagick.