### PR TITLE
Adjust fedora memory settings

### DIFF
--- a/roles/fedora/defaults/main.yml
+++ b/roles/fedora/defaults/main.yml
@@ -4,9 +4,9 @@
 # tomcat PermGen memory (for loading java classes, etc.)
 tomcat_permgen_memory: 128M
 # tomcat min memory allocation
-tomcat_min_memory: 512m
+tomcat_min_memory: 1024m
 # tomcat max memory allocation
-tomcat_max_memory: 4096m
+tomcat_max_memory: 2048m
 
 fedora_config_file: /etc/default/tomcat7
 


### PR DESCRIPTION
After reviewing documentation at https://wiki.duraspace.org/display/FEDORA4x/Best+Practices+-+Fedora+Configuration
I think we should adjust our max memory allocation to 2048 instead of
4096. I am hopeful this will prevent OOM errors that we've been seeing
for FRBM.

Connected to https://github.com/MPLSFedResearch/cypripedium/issues/329