### PR TITLE
Updates to roles for Ubuntu 18.04

### DIFF
--- a/roles/fedora/defaults/main.yml
+++ b/roles/fedora/defaults/main.yml
@@ -8,7 +8,7 @@ tomcat_min_memory: 1024m
 # tomcat max memory allocation
 tomcat_max_memory: 2048m
 
-fedora_config_file: /etc/default/tomcat7
+fedora_config_file: /etc/default/tomcat8
 
 fedora_version: 4.7.5
 fedora_database: jdbc-postgresql

--- a/roles/fedora/tasks/main.yml
+++ b/roles/fedora/tasks/main.yml
@@ -28,44 +28,44 @@
 
 - name: install servlet container package
   become: yes
-  package: name=tomcat7 state=present
+  package: name=tomcat8 state=present
 
 - name: download fedora
   get_url: url=http://repo1.maven.org/maven2/org/fcrepo/fcrepo-webapp/{{ fedora_version }}/fcrepo-webapp-{{ fedora_version }}.war owner={{ ansible_ssh_user }} dest={{ install_path }}/fcrepo-webapp-{{ fedora_version }}.war timeout=100
 
 - name: make fedora data dir
-  file: owner=tomcat7 group=tomcat7 state=directory path=/opt/fedora-data
+  file: owner=tomcat8 group=tomcat8 state=directory path=/opt/fedora-data
   become: yes
 
 - name: check fedora.war
-  stat: path=/var/lib/tomcat7/webapps/fedora.war
+  stat: path=/var/lib/tomcat8/webapps/fedora.war
   register: fedora_war
 
 - name: copy over fedora.war
   become: yes
-  command: cp {{ install_path }}/fcrepo-webapp-{{ fedora_version }}.war /var/lib/tomcat7/webapps/fedora.war
+  command: cp {{ install_path }}/fcrepo-webapp-{{ fedora_version }}.war /var/lib/tomcat8/webapps/fedora.war
   when: fedora_war.stat.exists == False
 
 - name: create tomcat config and java options
   become: yes
   template:
-    src: tomcat7.j2
+    src: tomcat8.j2
     dest: "{{ fedora_config_file }}"
-    owner: tomcat7
-    group: tomcat7
+    owner: tomcat8
+    group: tomcat8
     backup: yes
 
 - name: set port for tomcat
   become: yes
   replace:
-    dest: /etc/tomcat7/server.xml
+    dest: /etc/tomcat8/server.xml
     regexp: "8080"
     replace: "{{ tomcat_port }}"
 
 - name: add log rotation for catalina.out (tomcat/fedora logs)
   become: yes
-  template: src=logrotate-tomcat dest=/etc/logrotate.d/tomcat7 backup=yes
+  template: src=logrotate-tomcat dest=/etc/logrotate.d/tomcat8 backup=yes
 
 - name: restart servlet
   become: yes
-  service: name=tomcat7 enabled=yes state=restarted
+  service: name=tomcat8 enabled=yes state=restarted

--- a/roles/fedora/templates/logrotate-tomcat
+++ b/roles/fedora/templates/logrotate-tomcat
@@ -1,8 +1,8 @@
-/var/log/tomcat7/catalina.out {
+/var/log/tomcat8/catalina.out {
   copytruncate
   weekly
   rotate 52
   compress
   missingok
-  create 640 tomcat7 adm
+  create 640 tomcat8 adm
 }

--- a/roles/fedora/templates/tomcat8.j2
+++ b/roles/fedora/templates/tomcat8.j2
@@ -1,11 +1,11 @@
 # Ansible created this file and made a timestamped backup of the original
 # This template will construct settings that look something like
-# TOMCAT7_USER=tomcat7
+# TOMCAT8_USER=tomcat8
 # or
 # TOMCAT_GROUP=tomcat
-TOMCAT7_USER=tomcat7
-TOMCAT7_GROUP=tomcat7
-# JAVA_OPTS="-Dfcrepo.home=/opt/fedora-data -Dfcrepo.modeshape.configuration=classpath:/config/{{ fedora_database }}/repository.json -Djava.awt.headless=true -XX:+UseG1GC -XX:+UseCompressedOops -XX:-UseLargePagesIndividualAllocation -XX:MaxPermSize={{ tomcat_permgen_memory }} -Xms{{ tomcat_min_memory }} -Xmx{{ tomcat_max_memory }} -Djava.util.logging.config.file=/etc/tomcat7/logging.properties -server"
+TOMCAT8_USER=tomcat8
+TOMCAT8_GROUP=tomcat8
+# JAVA_OPTS="-Dfcrepo.home=/opt/fedora-data -Dfcrepo.modeshape.configuration=classpath:/config/{{ fedora_database }}/repository.json -Djava.awt.headless=true -XX:+UseG1GC -XX:+UseCompressedOops -XX:-UseLargePagesIndividualAllocation -XX:MaxPermSize={{ tomcat_permgen_memory }} -Xms{{ tomcat_min_memory }} -Xmx{{ tomcat_max_memory }} -Djava.util.logging.config.file=/etc/tomcat8/logging.properties -server"
 
 JAVA_OPTS="${JAVA_OPTS} -Dfcrepo.home=/opt/fedora-data"
 JAVA_OPTS="${JAVA_OPTS} -Dfcrepo.modeshape.configuration=classpath:/config/jdbc-postgresql/repository.json"
@@ -20,5 +20,5 @@ JAVA_OPTS="${JAVA_OPTS} -XX:-UseLargePagesIndividualAllocation"
 JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize={{ tomcat_permgen_memory }}"
 JAVA_OPTS="${JAVA_OPTS} -Xms{{ tomcat_min_memory }}"
 JAVA_OPTS="${JAVA_OPTS} -Xmx{{ tomcat_max_memory }}"
-JAVA_OPTS="${JAVA_OPTS} -Djava.util.logging.config.file=/etc/tomcat7/logging.properties"
+JAVA_OPTS="${JAVA_OPTS} -Djava.util.logging.config.file=/etc/tomcat8/logging.properties"
 JAVA_OPTS="${JAVA_OPTS} -server"

--- a/roles/fits/tasks/main.yml
+++ b/roles/fits/tasks/main.yml
@@ -74,45 +74,45 @@
 
 - name: install servlet container package
   become: yes
-  package: name=tomcat7 state=present
+  package: name=tomcat8 state=present
 
 - name: download fits servlet version {{ fits_servlet_version }}
   become: yes
   get_url:
     url: 'https://projects.iq.harvard.edu/files/fits/files/fits-{{ fits_servlet_version }}.war'
-    owner: tomcat7
-    group: tomcat7
+    owner: tomcat8
+    group: tomcat8
     dest: '{{ install_path }}/fits-{{ fits_servlet_version }}.war'
     checksum: 'sha256:{{ fits_servlet_checksum }}'
     force: yes
 
 - name: copy over fits.war
   become: yes
-  command: cp {{ install_path }}/fits-{{ fits_servlet_version }}.war /var/lib/tomcat7/webapps/fits-{{ fits_servlet_version }}.war
+  command: cp {{ install_path }}/fits-{{ fits_servlet_version }}.war /var/lib/tomcat8/webapps/fits-{{ fits_servlet_version }}.war
 
 - name: copy catalina properties
   become: yes
   template:
     src: catalina.properties.j2
-    dest: /etc/tomcat7/catalina.properties
-    owner: tomcat7
-    group: tomcat7
+    dest: /etc/tomcat8/catalina.properties
+    owner: tomcat8
+    group: tomcat8
     backup: yes
 
 - name: set port for tomcat
   become: yes
   replace:
-    dest: /etc/tomcat7/server.xml
+    dest: /etc/tomcat8/server.xml
     regexp: "8080"
     replace: "{{ tomcat_port }}"
 
 - name: add log rotation for catalina.out (tomcat/fedora logs)
   become: yes
-  template: src=logrotate-tomcat dest=/etc/logrotate.d/tomcat7 backup=yes
+  template: src=logrotate-tomcat dest=/etc/logrotate.d/tomcat8 backup=yes
 
 - name: restart servlet
   become: yes
-  service: name=tomcat7 enabled=yes state=restarted
+  service: name=tomcat8 enabled=yes state=restarted
 
 - name: check that fits-servlet is up
   uri:

--- a/roles/fits/templates/catalina.properties.j2
+++ b/roles/fits/templates/catalina.properties.j2
@@ -184,7 +184,7 @@ org.apache.catalina.startup.ContextConfig.jarsToSkip=
 
 # Additional JARs (over and above the default JARs listed above) to skip when
 # scanning for TLDs. The list must be a comma separated list of JAR file names.
-org.apache.catalina.startup.TldConfig.jarsToSkip=tomcat7-websocket.jar
+org.apache.catalina.startup.TldConfig.jarsToSkip=tomcat8-websocket.jar
 
 #
 # String cache configuration.

--- a/roles/fits/templates/logrotate-tomcat
+++ b/roles/fits/templates/logrotate-tomcat
@@ -1,8 +1,8 @@
-/var/log/tomcat7/catalina.out {
+/var/log/tomcat8/catalina.out {
   copytruncate
   weekly
   rotate 52
   compress
   missingok
-  create 640 tomcat7 adm
+  create 640 tomcat8 adm
 }

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -40,8 +40,7 @@
     - curl
     - htop
     - openssl
-    - libreadline6
-    - libreadline6-dev
+    - libreadline-dev
     - zlib1g
     - zlib1g-dev
     - libssl-dev

--- a/roles/restart/tasks/main.yml
+++ b/roles/restart/tasks/main.yml
@@ -12,11 +12,11 @@
   service:
     name: solr
     state: restarted
-    
+
 - name: restart fedora
   become: yes
   service:
-    name: tomcat7
+    name: tomcat8
     enabled: yes
     state: restarted
 


### PR DESCRIPTION
This changes the `packages` role to include
renamed packages and replaces all refs
to `tomcat7` to `tomcat8`, which is the
version that comes with 18.04

Connected to tenejo#148