### PR TITLE
Ensure directory for passenger temp files persists

### DIFF
--- a/roles/apache/tasks/main.yml
+++ b/roles/apache/tasks/main.yml
@@ -26,6 +26,10 @@
     - libaprutil1-dev
     - apache2-dev
 
+- name: ensure directory for passenger temp files persists across reboots
+  become: yes
+  template: src=passenger_tmpfiles.j2 dest=/usr/lib/tmpfiles.d/passenger.conf owner=root group=root backup=no
+
 - name: install passenger-install-apache2-module
   become: yes
   shell: passenger-install-apache2-module --auto creates={{ system_gem_path.stdout }}/gems/passenger-{{ passenger_ver }}/buildout/apache2/mod_passenger.so

--- a/roles/apache/templates/passenger_tmpfiles.j2
+++ b/roles/apache/templates/passenger_tmpfiles.j2
@@ -1,0 +1,2 @@
+# Directory for Passenger sockets, lockfiles and stats tempfiles
+d {{ passenger_inst_reg_dir }} 2775 root root - -


### PR DESCRIPTION
The default location for passenger temp files (e.g., PID files) differs
between Red Hat and Ubuntu. This causes problems for us because we are
often deploying an application to both environments and it's better if
we can have a standard place.

Our passenger setup is configured to use /var/run/passenger-instreg, but
that directory does not persist across a hard reboot. The recommended
way of fixing that in Ubuntu these days is to add an entry to
/usr/lib/tempdirs.d

This commit adds that file for passenger, which should fix the behavior
we've been seeing that passenger does not restart after reboot
(it's trying to start, but it can't write its PID file so it fails).

References:

http://manpages.ubuntu.com/manpages/xenial/en/man5/tmpfiles.d.5.html
https://serverfault.com/questions/74796/directory-in-var-run-gets-deleted-after-hard-reboot

Connected to https://github.com/curationexperts/in-house/issues/280
