### PR TITLE
Use conf instead of config to match latest AF

### DIFF
--- a/roles/first_deploy/tasks/main.yml
+++ b/roles/first_deploy/tasks/main.yml
@@ -78,15 +78,15 @@
 
 - name: temporary symlink schema from git checkout to solr - managed-schema
   become: yes
-  file: src=/home/{{ ansible_ssh_user }}/{{ project_name }}/solr/config/schema.xml dest=/var/solr/data/{{ project_name }}/conf/managed-schema state=link force=yes
+  file: src=/home/{{ ansible_ssh_user }}/{{ project_name }}/solr/conf/schema.xml dest=/var/solr/data/{{ project_name }}/conf/managed-schema state=link force=yes
 
 - name: temporary symlink schema from git checkout to solr - schema.xml
   become: yes
-  file: src=/home/{{ ansible_ssh_user }}/{{ project_name }}/solr/config/schema.xml dest=/var/solr/data/{{ project_name }}/conf/schema.xml state=link force=yes
+  file: src=/home/{{ ansible_ssh_user }}/{{ project_name }}/solr/conf/schema.xml dest=/var/solr/data/{{ project_name }}/conf/schema.xml state=link force=yes
 
 - name: temporary symlink solrconfig from git checkout to solr
   become: yes
-  file: src=/home/{{ ansible_ssh_user }}/{{ project_name }}/solr/config/solrconfig.xml dest=/var/solr/data/{{ project_name }}/conf/solrconfig.xml state=link force=yes
+  file: src=/home/{{ ansible_ssh_user }}/{{ project_name }}/solr/conf/solrconfig.xml dest=/var/solr/data/{{ project_name }}/conf/solrconfig.xml state=link force=yes
 
 - name: restart solr
   become: true
@@ -99,15 +99,15 @@
 
 - name: symlink solrconfig from code to solr
   become: yes
-  file: src=/opt/{{ project_name }}/current/solr/config/solrconfig.xml dest=/var/solr/data/{{ project_name }}/conf/solrconfig.xml state=link force=yes
+  file: src=/opt/{{ project_name }}/current/solr/conf/solrconfig.xml dest=/var/solr/data/{{ project_name }}/conf/solrconfig.xml state=link force=yes
 
 - name: symlink schema from code to solr - managed-schema
   become: yes
-  file: src=/opt/{{ project_name }}/current/solr/config/schema.xml dest=/var/solr/data/{{ project_name }}/conf/managed-schema state=link force=yes
+  file: src=/opt/{{ project_name }}/current/solr/conf/schema.xml dest=/var/solr/data/{{ project_name }}/conf/managed-schema state=link force=yes
 
 - name: symlink schema from git checkout to solr - schema.xml
   become: yes
-  file: src=/home/{{ ansible_ssh_user }}/{{ project_name }}/solr/config/schema.xml dest=/var/solr/data/{{ project_name }}/conf/schema.xml state=link force=yes
+  file: src=/home/{{ ansible_ssh_user }}/{{ project_name }}/solr/conf/schema.xml dest=/var/solr/data/{{ project_name }}/conf/schema.xml state=link force=yes
 
 - name: restart solr
   become: true


### PR DESCRIPTION
active-fedora has changed its expectations around the location of solr
config files, from config to conf, to match what Blacklight does. We
need to update our build scripts to match.