### PR TITLE
Use sudo and systemctl to manage sidekiq

### DIFF
--- a/docs/capification.md
+++ b/docs/capification.md
@@ -27,7 +27,7 @@
     gem 'capistrano-ext'
     gem 'capistrano-passenger'
     gem 'capistrano-rails'
-    gem 'capistrano-sidekiq', '~> 1.0.3'
+    gem 'capistrano-sidekiq'
     ```
   Add these to your top level Gemfile section if they aren't there yet:
     ```ruby
@@ -59,10 +59,6 @@
     set :bundle_env_variables, nokogiri_use_system_libraries: 1
     set :rails_env, 'production'
 
-    set :init_system, :systemd
-    set :service_unit_name, 'sidekiq.service'
-    set :sidekiq_user, 'deploy'
-
     set :keep_releases, 5
     set :assets_prefix, "#{shared_path}/public/assets"
 
@@ -76,6 +72,31 @@
     append :linked_files, "config/secrets.yml"
     append :linked_files, "config/database.yml"
     append :linked_files, ".env.production"
+
+
+  # We have to re-define capistrano-sidekiq's tasks to work with
+  # systemctl in production. Note that you must clear the previously-defined
+  # tasks before re-defining them.
+  Rake::Task["sidekiq:stop"].clear_actions
+  Rake::Task["sidekiq:start"].clear_actions
+  Rake::Task["sidekiq:restart"].clear_actions
+  namespace :sidekiq do
+    task :stop do
+      on roles(:app) do
+        execute :sudo, :systemctl, :stop, :sidekiq
+      end
+    end
+    task :start do
+      on roles(:app) do
+        execute :sudo, :systemctl, :start, :sidekiq
+      end
+    end
+    task :restart do
+      on roles(:app) do
+        execute :sudo, :systemctl, :restart, :sidekiq
+      end
+    end
+  end
   ```
 
   Note: You do NOT want the `:passenger_restart_with_touch` option. This will prevent passenger from automatically restarting after you deploy. See https://github.com/capistrano/passenger#restarting-passenger--4033-applications

--- a/roles/first_deploy/tasks/main.yml
+++ b/roles/first_deploy/tasks/main.yml
@@ -84,11 +84,6 @@
     mode: '0775'
     state: touch
 
-- name: install sidekiq systemd user service for deploy user
-  shell: BRANCH={{ branch | default('master') }} cap localhost sidekiq:install
-  args:
-    chdir: /home/{{ ansible_ssh_user }}/{{ project_name }}
-
 - name: create apache vhosts file
   become: yes
   template: src=apache_vhost.j2 dest=/etc/apache2/sites-enabled/{{ project_name }}.conf owner=root group=root backup=no

--- a/roles/sidekiq/tasks/main.yml
+++ b/roles/sidekiq/tasks/main.yml
@@ -1,3 +1,8 @@
+---
+- name: create sidekiq system service
+  become: yes
+  template: src=sidekiq.service.j2 dest=/lib/systemd/system/sidekiq.service owner=root group=root backup=no
+
 - name: enable redis system service
   become: yes
   systemd:
@@ -9,3 +14,20 @@
   systemd:
     name: redis
     state: started
+
+- name: enable sidekiq system service
+  become: yes
+  systemd:
+    name: sidekiq
+    enabled: yes
+    daemon_reload: yes
+
+- name: start sidekiq system service
+  become: yes
+  systemd:
+    name: sidekiq
+    state: started
+
+- name: allow deploy user to restart sidekiq
+  become: yes
+  template: src=sidekiq.sudoers.j2 dest=/etc/sudoers.d/sidekiq-restart-users owner=root group=root backup=no

--- a/roles/sidekiq/templates/sidekiq.service.j2
+++ b/roles/sidekiq/templates/sidekiq.service.j2
@@ -1,0 +1,48 @@
+#
+# systemd unit file for CentOS 7, Ubuntu 15.04
+#
+# Customize this file based on your bundler location, app directory, etc.
+# Put this in /usr/lib/systemd/system (CentOS) or /lib/systemd/system (Ubuntu).
+# Run:
+#   - systemctl enable sidekiq
+#   - systemctl {start,stop,restart} sidekiq
+#
+# This file corresponds to a single Sidekiq process.  Add multiple copies
+# to run multiple processes (sidekiq-1, sidekiq-2, etc).
+#
+# See Inspeqtor's Systemd wiki page for more detail about Systemd:
+# https://github.com/mperham/inspeqtor/wiki/Systemd
+#
+[Unit]
+Description=sidekiq
+# start us only once the network and logging subsystems are available,
+# consider adding redis-server.service if Redis is local and systemd-managed.
+After=syslog.target network.target redis-server.service
+
+# See these pages for lots of options:
+# http://0pointer.de/public/systemd-man/systemd.service.html
+# http://0pointer.de/public/systemd-man/systemd.exec.html
+[Service]
+Type=simple
+WorkingDirectory=/opt/{{ project_name }}/current
+# If you use rbenv:
+# ExecStart=/bin/bash -lc 'bundle exec sidekiq -e production'
+# If you use the system's ruby:
+ExecStart=/usr/local/bin/bundle exec sidekiq -e production -C config/sidekiq.yml -L log/sidekiq.log
+User=deploy
+Group=deploy
+UMask=0002
+
+# if we crash, restart
+RestartSec=1
+Restart=on-failure
+
+# output goes to /var/log/syslog
+StandardOutput=syslog
+StandardError=syslog
+
+# This will default to "bundler" if we don't specify it
+SyslogIdentifier=sidekiq
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/sidekiq/templates/sidekiq.sudoers.j2
+++ b/roles/sidekiq/templates/sidekiq.sudoers.j2
@@ -1,0 +1,4 @@
+deploy ALL=(ALL) NOPASSWD: /bin/systemctl start sidekiq
+deploy ALL=(ALL) NOPASSWD: /bin/systemctl stop sidekiq
+deploy ALL=(ALL) NOPASSWD: /bin/systemctl restart sidekiq
+deploy ALL=(ALL) NOPASSWD: /bin/systemctl status sidekiq


### PR DESCRIPTION
Although the latest capistrano-sidekiq gem has a different
recommendation for how to manage sidekiq systemctl services, we have
found it does not work consistently. We are going to keep using the
latest capistrano-sidekiq gem, but revert back to using a root managed
systemctl service for sidekiq.

Connected to https://github.com/curationexperts/in-house/issues/552