### PR TITLE
Remove version spec in Apache setup

### DIFF
--- a/roles/apache/tasks/main.yml
+++ b/roles/apache/tasks/main.yml
@@ -17,7 +17,7 @@
   become: yes
   gem: name=passenger user_install=no state=present version={{ passenger_ver }}
 
-- name: install apache packages for Ubuntu 20.04
+- name: install apache packages for Ubuntu
   become: yes
   package: name={{ item }} state=present
   with_items:


### PR DESCRIPTION
The exact same commands are uses in Ubuntu 16.x 18.x and 20.x.  Saying "Install packages for Ubuntu 20.x" makes is sound like this task wouldn't work perfectly well on 16 or 18 (or possibly 21 or 22).