### PR TITLE
Handle Ansible checksum deprecation

### DIFF
--- a/roles/ruby/tasks/main.yml
+++ b/roles/ruby/tasks/main.yml
@@ -52,7 +52,7 @@
       state: directory
 
   - name: download ruby
-    get_url: url={{ ruby_gzip_url }} sha256sum={{ ruby_sha_256 }}  dest={{ install_path }}/ruby-{{ ruby_version}}.tar.gz
+    get_url: url={{ ruby_gzip_url }} checksum="sha256:{{ ruby_sha_256 }}"  dest={{ install_path }}/ruby-{{ ruby_version}}.tar.gz
 
   - name: unzip ruby file
     unarchive: src={{ install_path }}/ruby-{{ ruby_version}}.tar.gz dest={{ install_path }}/ creates={{ install_path }}/ruby-{{ ruby_version}}/compile.c copy=no


### PR DESCRIPTION
```
TASK [ruby : download ruby] ****************************************************************************************************
[DEPRECATION WARNING]: The parameter "sha256sum" has been deprecated and will be removed, use "checksum" instead. This feature 
will be removed from ansible-core in version 2.14. Deprecation warnings can be disabled by setting deprecation_warnings=False 
in ansible.cfg.
```

See also https://docs.ansible.com/ansible/latest/collections/ansible/builtin/get_url_module.html#parameter-sha256sum & https://docs.ansible.com/ansible/latest/collections/ansible/builtin/get_url_module.html#parameter-checksum