### PR TITLE
Update capistrano_setup and simplify first_deploy

### DIFF
--- a/roles/capistrano_setup/tasks/main.yml
+++ b/roles/capistrano_setup/tasks/main.yml
@@ -74,10 +74,3 @@
     groups: deploy
     append: yes
 
-- name: "create capistrano skeleton"
-  become: yes
-  file: path=/opt/{{ project_name }}/{{ item }} owner=deploy group=deploy state=directory
-  loop:
-     - releases
-     - repo
-     - shared/config

--- a/roles/first_deploy/tasks/main.yml
+++ b/roles/first_deploy/tasks/main.yml
@@ -13,6 +13,10 @@
     path: /home/{{ ansible_ssh_user }}/.ssh/known_hosts
     state: absent
 
+- name: "create shared project directory"
+  become: yes
+  file: path=/opt/{{ project_name }} owner=deploy group=deploy state=directory
+
 - name: generate rails secret
   command: openssl rand -hex 64
   register: rails_secret
@@ -102,6 +106,12 @@
       shell: gem install bundler -v "{{ bundler_version }}"
   when: bundler_preinstalled.failed
 
+- name: install gems (bundle install)
+  become: yes
+  shell: bundle install
+  args:
+    chdir: /home/{{ ansible_ssh_user }}/{{ project_name }}
+
   # Set up a keypair so the ansible user can connect as the capistrano deploy user
 - name: create deployment keypair for connection user
   user:
@@ -119,7 +129,6 @@
   authorized_key:
       user: deploy
       key: "{{ public_key.content | b64decode }}"
-
 
 - name: ensure ansible user is in the deploy group
   become: yes


### PR DESCRIPTION
* Create the project directory with the deploy user as owner
(instead of the ansible user). This allows Capistrano to
automatically and dynamically create any shared directories
declared in the project repository (config/deploy.rb, etc.)
* Install gems for the ansible_user so that user can run a
Capistrano deployment from localhost
* Remove project references in the capistano_setup task so it can
be run to build project-agnostic AMIs