### PR TITLE
Ensure /opt/data directory exists and is owned by deploy

### DIFF
--- a/roles/configure_new_box/tasks/main.yml
+++ b/roles/configure_new_box/tasks/main.yml
@@ -84,6 +84,7 @@
     - /opt/{{ project_name }}/releases
     - /opt/derivatives
     - /opt/uploads
+    - /opt/data
     - /home/deploy/.ssh
   tags:
     - capistrano


### PR DESCRIPTION
Our current production builds for Hyrax consolidate most application
data under the /opt/data directory.  This change ensures that the
parent folder exists with the correct ownership so that the application
can make subfolders as needed.