### PR TITLE
Enable Apache mod_ssl on all installations

### DIFF
--- a/roles/apache/tasks/main.yml
+++ b/roles/apache/tasks/main.yml
@@ -76,12 +76,15 @@
 
 - name: remove default apache site
   become: yes
-  file: path=/etc/apache2/sites-enabled/000-default.conf state=absent
+  command: a2dissite 000-default
 
 - name: enable rewrite module
   become: yes
   command: a2enmod rewrite
 
+- name: enable ssl module
+  become: yes
+  command: a2enmod ssl
 
 - name: restart apache
   become: yes


### PR DESCRIPTION
**ISSUE**
SSL/TLS support is now required on all websites.

**SOLUTION**
Enable mod_ssl support as part of the default installation.  This allows us to eliminate a separate SSL installation role and permits use of modern certificate management tools like certbot with letsencrypt.