### PR TITLE
Make Fedora and Cantaloupe configuration optional

### DIFF
--- a/roles/configure_new_box/defaults/main.yml
+++ b/roles/configure_new_box/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 
 #### fedora defaults
+configure_fedora: True
 fedora_config_file: /etc/default/tomcat9
 fedora_database: jdbc-postgresql
 # tomcat PermGen memory (for loading java classes, etc.)
@@ -19,6 +20,7 @@ solr_min_mem: 512
 solr_max_mem: 1024
 
 #### cantaloupe defaults
+configure_cantaloupe: True
 cantaloupe_version: '5.0.3'
 cantaloupe_cache_dir: /var/cache/cantaloupe
 cantaloupe_log_dir: /var/log/cantaloupe

--- a/roles/configure_new_box/tasks/main.yml
+++ b/roles/configure_new_box/tasks/main.yml
@@ -1,3 +1,9 @@
+- name: Ensure backup script directory exists
+  become: yes
+  file:
+    path: /opt/pg_backups/pg_daily_double
+    state: directory
+
 - name: add pg_backups script
   become: yes
   template: src=pg_backups.j2 dest=/opt/pg_backups/pg_daily_double owner=root group=root mode=0755
@@ -37,33 +43,37 @@
     - postgres
     - configure
 
-- name: create fcrepo database
-  postgresql_db: name=fcrepo state=present login_user=postgres owner=tomcat
-  become: yes
-  become_user: postgres
-  tags:
-    - postgres
-    - fedora
-    - configure
+- name: configure Fedora
+  when: configure_fedora == True
+  block: 
+  - name: create fcrepo database
+    postgresql_db: name=fcrepo state=present login_user=postgres owner=tomcat
+    become: yes
+    become_user: postgres
+    tags:
+      - postgres
+      - fedora
+      - configure
 
-- name: create Fedora config and java options
-  become: yes
-  template:
-    src: tomcat9.j2
-    dest: "{{ fedora_config_file }}"
-    owner: tomcat
-    group: tomcat
-    backup: yes
-  tags:
-    - fedora
-    - configure
+  - name: create Fedora config and java options
+    become: yes
+    template:
+      src: tomcat9.j2
+      dest: "{{ fedora_config_file }}"
+      owner: tomcat
+      group: tomcat
+      backup: yes
+    tags:
+      - fedora
+      - configure
 
-- name: restart Fedora servlet
-  become: yes
-  systemd: name=tomcat9 state=restarted daemon_reload=yes
-  tags:
-    - fedora
-    - configure
+  - name: restart Fedora servlet
+    become: yes
+    systemd: name=tomcat9 state=restarted daemon_reload=yes
+    tags:
+      - fedora
+      - configure
+  # block end - configure Fedora
 
 - name: create default solr collection
   become: yes
@@ -90,28 +100,26 @@
     - capistrano
     - configure
 
-- name: write cantaloupe config file
-  become: yes
-  template:
-    src: ansible-samvera/roles/cantaloupe/templates/cantaloupe.properties
-    dest: /opt/cantaloupe-{{ cantaloupe_version }}/cantaloupe.properties
-    owner: cantaloupe
-    group: cantaloupe
-    mode: 0644
-  tags:
-    - cantaloupe
-    - configure
+- name: configure Cantaloupe
+  when: configure_cantaloupe == True
+  block:
+  - name: write cantaloupe config file
+    become: yes
+    template:
+      src: ansible-samvera/roles/cantaloupe/templates/cantaloupe.properties
+      dest: /opt/cantaloupe-{{ cantaloupe_version }}/cantaloupe.properties
+      owner: cantaloupe
+      group: cantaloupe
+      mode: 0644
+    tags:
+      - cantaloupe
+      - configure
 
-- name: (re)start cantaloupe
-  become: yes
-  shell: systemctl restart cantaloupe.service
-  tags:
-    - cantaloupe
-    - configure
+  - name: (re)start cantaloupe
+    become: yes
+    shell: systemctl restart cantaloupe.service
+    tags:
+      - cantaloupe
+      - configure
+  # end block - configure Cantaloupe
 
-- name: configure collectd
-  become: yes
-  template: src=collectd.conf.j2 dest=/opt/collectd/etc/collectd.conf owner=root group=root backup=no
-  tags:
-    - collectd
-    - configure


### PR DESCRIPTION
**ISSUE**
We want to use the build scripts to build blacklight-only servers that don't require fedora or cantaloupe.

**SOLUTION**
* Add optional install flags for Fedora and Cantaloupe
* Set the flags to default to True (install by default for backward compatibility)
* Call the role with `configure_fedora: False` to skip installation
* Also removes Collectd since we no longer maintain Slunk and have not other tools to analyze data captured by CollectD