### PR TITLE
Update to use Java 17 via openJDK

### DIFF
--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -64,5 +64,5 @@
     - redis-server
     - xfsprogs
     - libsqlite3-dev
-    - openjdk-8-jdk-headless
+    - openjdk-17-jdk-headless
     - zip


### PR DESCRIPTION
Java 17 is currently the most recent LTS version and recommended by Apache for runing Solr.

See
https://endoflife.date/java
https://solr.apache.org/guide/solr/latest/deployment-guide/system-requirements.html#java-and-solr-combinations