### PR TITLE
Add support for capistrano-sidekiq `sidekiq:quiet` command.

### DIFF
--- a/roles/sidekiq/templates/sidekiq.sudoers.j2
+++ b/roles/sidekiq/templates/sidekiq.sudoers.j2
@@ -2,3 +2,4 @@ deploy ALL=(ALL) NOPASSWD: /bin/systemctl start sidekiq
 deploy ALL=(ALL) NOPASSWD: /bin/systemctl stop sidekiq
 deploy ALL=(ALL) NOPASSWD: /bin/systemctl restart sidekiq
 deploy ALL=(ALL) NOPASSWD: /bin/systemctl status sidekiq
+deploy ALL=(ALL) NOPASSWD: /bin/systemctl kill -s TSTP sidekiq


### PR DESCRIPTION
The command issued by Capistrano is
```
00:00 sidekiq:quiet
      01 sudo systemctl kill -s TSTP sidekiq
```