### PR TITLE
Add ca-certificates and redis-tools to list of packages to install

### DIFF
--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -37,6 +37,7 @@
     - build-essential
     - git
     - git-core
+    - ca-certificates
     - curl
     - htop
     - openssl
@@ -62,6 +63,7 @@
     - libcurl4-openssl-dev
     - libxvidcore-dev
     - redis-server
+    - redis-tools
     - xfsprogs
     - libsqlite3-dev
     - openjdk-17-jdk-headless


### PR DESCRIPTION
Checking the certificates is generally good practice and and has no negative side effects.

Adding redis-tools allows us to support the Puma application server more efficiently.