### PR TITLE
Add a role to install Redis

### DIFF
--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+# ROLE: redis
+# roles/redis/tasks/main.yml
+#
+# Installs the most recent version of redis server and tools
+# Usage:
+#    - { role: redis }
+#
+- name: add redis gpg key to keyring
+  become: yes
+  apt_key:
+    url: https://packages.redis.io/gpg
+    keyring: /usr/share/keyrings/redis-archive-keyring.gpg
+
+- name: add Redis apt repository
+  become: yes
+  apt_repository:
+    repo: "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb {{ ansible_distribution_release }} main"
+    filename: redis
+    state: present
+    update_cache: false
+
+- name: install Redis via apt repository
+  become: yes
+  package: name=redis state=present


### PR DESCRIPTION
Installs the latest Redis server and tools from the Redis project apt repository. Based on the recommended installation procedure from the Redis website.

See: Install Redis on Linux @ https://redis.io/docs/latest/operate/oss_and_stack/install/archive/install-redis/install-redis-on-linux/