### PR TITLE
Add Ruby installation via SNAP package

### DIFF
--- a/roles/ruby_via_snap/tasks/main.yml
+++ b/roles/ruby_via_snap/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+# ROLE: ruby_via_snap
+# roles/ruby_via_snap/tasks/main.yml
+#
+# Installs the specified ruby version using Snap
+# NOTE: must provide a valid ruby snap channel
+#
+# Usage:
+#    - { role: ruby_via_snap, ruby_version: '3.4/stable'  }
+#
+# Reads https://cache.ruby-lang.org/pub/ruby/index.txt
+# to find download URL and checksum
+
+- name: remove package ruby
+  become: yes
+  package: name=ruby state=absent
+
+- name: install ruby via snap (channel={{ ruby_channel }})
+  snap: 
+    name: ruby
+    channel: "{{ ruby_channel }}"
+    classic: true
+
+- name: update rubygems
+  become: yes
+  command: gem update --system


### PR DESCRIPTION
This adds a simplified role to install ruby via Snap.

Snap only provides the most recent patch version of each release, so you must specify a `ruby_channel` matching a valid major/minor release, and optionally a track (stable/edge/etc.) If no channel is supplied the role will default to the most recent stable release.

Asuming you have specified `ruby_channel=3.2`, you may want to update your application Gemfile to specify the ruby version something like
```
ruby '~> 3.1.0'
```
since the patch level on the server might vary.